### PR TITLE
Make validateIdentifiers a truthy experience in both Agent and Group

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -34,7 +34,7 @@ class Agent extends Element {
   }
 
   protected function validateIdentifiers($used_identifiers) {
-    return $used_identifiers !== 1;
+    return $used_identifiers === 1;
   }
 
   public function validate() {
@@ -44,7 +44,7 @@ class Agent extends Element {
     $used_identifiers = $this->countIdentifiers();
 
     // Checks that only one identifier is used.
-    if ($this->validateIdentifiers($used_identifiers)) {
+    if (!$this->validateIdentifiers($used_identifiers)) {
       $errors[] = new Error($this->identifierError($used_identifiers));
     }
 

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -42,9 +42,10 @@ class Agent extends Element {
 
     // Gets the used identifiers.
     $used_identifiers = $this->countIdentifiers();
+    $hasOneIdent = $this->validateIdentifiers($used_identifiers);
 
     // Checks that only one identifier is used.
-    if (!$this->validateIdentifiers($used_identifiers)) {
+    if (!$hasOneIdent) {
       $errors[] = new Error($this->identifierError($used_identifiers));
     }
 

--- a/src/Group.php
+++ b/src/Group.php
@@ -15,7 +15,7 @@ class Group extends Agent {
   protected function validateIdentifiers($used_identifiers) {
     $members = $this->getPropValue('member') ?: null;
     $validateIdentifiers = parent::validateIdentifiers($used_identifiers);
-    $validateMembers = $members === null || count($members) === 0;
+    $validateMembers = $members !== null && count($members) > 0;
     return $validateIdentifiers && $validateMembers;
   }
 }

--- a/src/Group.php
+++ b/src/Group.php
@@ -13,9 +13,9 @@ class Group extends Agent {
   }
 
   protected function validateIdentifiers($used_identifiers) {
-    $members = $this->getPropValue('member') ?: null;
-    $validateIdentifiers = parent::validateIdentifiers($used_identifiers);
-    $validateMembers = $members === null || count($members) > 0;
-    return $validateIdentifiers && $validateMembers;
+    $members = $this->getPropValue('member');
+    $hasOneIdent = parent::validateIdentifiers($used_identifiers);
+    $hasMembers = !is_null($members) && count($members) > 0;
+    return $hasOneIdent || (!$hasOneIdent && $hasMembers);
   }
 }

--- a/src/Group.php
+++ b/src/Group.php
@@ -15,7 +15,7 @@ class Group extends Agent {
   protected function validateIdentifiers($used_identifiers) {
     $members = $this->getPropValue('member') ?: null;
     $validateIdentifiers = parent::validateIdentifiers($used_identifiers);
-    $validateMembers = $members !== null && count($members) > 0;
+    $validateMembers = $members === null || count($members) > 0;
     return $validateIdentifiers && $validateMembers;
   }
 }


### PR DESCRIPTION
Addresses #14 

The Group returned `true` for `validateIdentifiers` when valid, whereas the `Agent` worked on the assumption that `false` would get returned when valid. 

Both have been brought in line so that valid identifier conditions now return `true` from both.
